### PR TITLE
Adding ability to merge tags

### DIFF
--- a/elementactions/TagManager_MergeElementAction.php
+++ b/elementactions/TagManager_MergeElementAction.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Craft;
+
+class TagManager_MergeElementAction extends BaseElementAction
+{
+    public function getName()
+    {
+        return Craft::t('Merge Tags');
+    }
+
+    public function getTriggerHtml()
+    {
+        $js = 'new Craft.ElementActionTrigger({
+                  handle: '.JsonHelper::encode($this->getClassHandle()).',
+                  validateSelection: function($selectedElements){ return $selectedElements.length > 1; },
+              });
+
+              $("#TagManager_Merge-actiontrigger").on("click", function() {
+                var elements = Craft.elementIndex.getSelectedElements();
+                var list = $(".merge-tags-list");
+
+                list.empty();
+
+                $.each(elements, function(index, element) {
+                    list.append("<li><a class=\'formsubmit\' data-param=\'merge_id\' data-value=" + element.dataset.id + ">" + element.innerText + "</a></li>");
+                });
+
+                $(document).ready(function() {
+                    Craft.initUiElements();
+                });
+
+                $(document).on("click", ".formsubmit", function(ev) {
+                    // Code adapted from formsubmit function in craft.js:1411
+
+                    var $btn = $(ev.currentTarget);
+                    var $form = $("#TagManager_Merge-actiontrigger");
+
+              			if ($btn.attr("data-param"))
+              			{
+              				$("<input type=\'hidden\'/>")
+              					.attr({
+              						name: $btn.attr("data-param"),
+              						value: $btn.attr("data-value")
+              					})
+              					.appendTo($form);
+              			}
+
+              			$form.submit();
+
+                    $("#merge-tags-menu").hide();
+              	});
+              });';
+
+        craft()->templates->includeJs($js);
+        craft()->templates->includeCss('h3.merge-tags-intro { padding-top: 14px; }');
+
+        return craft()->templates->render('tagmanager/_mergeTrigger');
+    }
+
+    public function isDestructive()
+    {
+        return true;
+    }
+
+    public function performAction(ElementCriteriaModel $criteria)
+    {
+        $mergeId = $this->getParams()->merge_id;
+        $elementIds = $criteria->ids();
+
+        foreach ($elementIds as $elementId)
+        {
+            if ($elementId != $mergeId) {
+                if (!craft()->elements->mergeElementsByIds($elementId, $mergeId)) {
+                    $this->setMessage(Craft::t('An error occurred while merging tags.'));
+                    return false;
+                }
+            }
+        }
+
+        // Success!
+        $this->setMessage(Craft::t('Tags merged successfully.'));
+        return true;
+    }
+
+    protected function defineParams()
+    {
+        return array(
+            'merge_id' => array(AttributeType::Number, 'required' => true)
+        );
+    }
+}

--- a/elementtypes/TagManagerElementType.php
+++ b/elementtypes/TagManagerElementType.php
@@ -56,6 +56,10 @@ class TagManagerElementType extends TagElementType
         ));
         $actions[] = $deleteAction;
 
+        // Merge
+        $mergeAction = craft()->elements->getAction('TagManager_Merge');
+        $actions[] = $mergeAction;
+
         // Allow plugins to add additional actions
         $allPluginActions = craft()->plugins->call('addTagManagerActions', array($source), true);
         foreach ($allPluginActions as $pluginActions) {

--- a/templates/_mergeTrigger.twig
+++ b/templates/_mergeTrigger.twig
@@ -1,0 +1,6 @@
+<div class="btn menubtn" role="button">{{ "Merge Tags"|t }}</div>
+<div class="menu" id="merge-tags-menu">
+    <h3 class="merge-tags-intro">Merge Selected Tags Into:</h3>
+    <hr>
+    <ul class="merge-tags-list"></ul>
+</div>


### PR DESCRIPTION
Hello!

Wanted to put this here for your thoughts. A client project needed the ability to merge tags, instead of just renaming them. I thought it might be a useful feature for others since Craft allows tags to have the same string.

The merge implementation was straightforward thanks to a merge function on [ElementsService](https://craftcms.com/classreference/services/ElementsService#mergeElementsByIds-detail). But I did have trouble getting the dropdown menu of tags to work as expected. The issue came down to the fact that I add tags to a list with jQuery when the menu is displayed. I couldn't find how to get Craft's click handlers to stick, and instead had to write my own.

I'd appreciate your thoughts on improvements, and if you think this is something you'd be interested in merging. Thanks!
